### PR TITLE
Rename Meeshkan to HMT in logs

### DIFF
--- a/hmt/build/builder.py
+++ b/hmt/build/builder.py
@@ -328,7 +328,7 @@ def update_operation(
             response = update_response(existing_response, mode, exchange)
         else:
             raise ValueError(
-                "Meeshkan is not smart enough to build responses from references yet. Coming soon!"
+                "HMT is not smart enough to build responses from references yet. Coming soon!"
             )
     else:
         response = build_response(exchange, mode)

--- a/hmt/serve/mock/server.py
+++ b/hmt/serve/mock/server.py
@@ -106,4 +106,4 @@ class MockServer:
                             + path
                         )
 
-        logger.info("Meeshkan is running")
+        logger.info("HMT is running")

--- a/hmt/serve/record/proxy.py
+++ b/hmt/serve/record/proxy.py
@@ -64,7 +64,7 @@ class RecordProxyRunner:
 
     def run(self):
 
-        logger.info("Starting Meeshkan record on http://localhost:%s", self._port)
+        logger.info("Starting HMT record on http://localhost:%s", self._port)
         logger.info(
             "Spec generation mode is %s",
             self._mode.name.lower() if self._mode else "disabled",
@@ -74,5 +74,5 @@ class RecordProxyRunner:
         ) as callback:
             server = RecordProxy(callback, self._routing)
             server.listen(self._port)
-            logger.info("Meeshkan is running")
+            logger.info("HMT is running")
             tornado.ioloop.IOLoop.instance().start()

--- a/hmt/tutorial/__init__.py
+++ b/hmt/tutorial/__init__.py
@@ -92,7 +92,7 @@ async def read_stream(p, server_started):
     try:
         while p.poll() is None:
             line = p.stdout.readline()
-            if "Meeshkan is running" in line:
+            if "HMT is running" in line:
                 server_started.set_result(0)
             await asyncio.sleep(0.1)
     finally:


### PR DESCRIPTION
I'm working on an HMT tutorial and realized that the logs still say `Meeshkan is running` or `Starting Meeshkan on...` so this PR updates that to HMT 💫 

I also created a branch (`rename-logs-from-main`) that makes these changes to `main` in case you decide to make that the default.

If anyone has advice for fixing the [failing CircleCI builds](https://app.circleci.com/pipelines/github/meeshkan/hmt), that'd be great. I know I need to update the node version in order to install and run pyright but I'm not exactly sure where... 🤔 